### PR TITLE
Hid scrollbars

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,6 @@
     <script src="http://cdnjs.cloudflare.com/ajax/libs/p5.js/0.5.6/p5.js"></script>
     <script src="sketch.js"></script>
   </head>
-  <body style="margin:0">
+  <body style="margin: 0; overflow: hidden;">
   </body>
 </html>


### PR DESCRIPTION
Added `overflow: hidden;` css tag to body to hide the scrollbars that are created when the canvas fills the window. These scrollbars normally don't matter, but for web apps like this they can really get in the way in fullscreen mode.