### PR TITLE
Random integer generation fix

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -45,11 +45,11 @@ function Symbol(x, y, speed, first, opacity) {
       if (charType > 1) {
         // set it to Katakana
         this.value = String.fromCharCode(
-          0x30A0 + round(random(0, 96))
+          0x30A0 + floor(random(0, 97))
         );
       } else {
         // set it to numeric
-        this.value = round(random(0,9));
+        this.value = floor(random(0,10));
       }
     }
   }


### PR DESCRIPTION
Changed round to floor to ensure every value has the same chances. For example, `round(random(0,9))` has lower chances for `0` and `9`, while `floor(random(0,10))` distributes the chances evenly. I only changed the digit and Katakana randomization to ensure the results stay the same.